### PR TITLE
Swaps from Shibboleth to SimpleSAML

### DIFF
--- a/ideabank_users.info
+++ b/ideabank_users.info
@@ -2,4 +2,6 @@ name = Ideabank users
 description = Customize the login page for ideabank applications.
 core = 7.x
 package = MIT
-version = "7.x-1.1"
+version = "7.x-1.2"
+dependencies[] = drupal:system (>= 7.40)
+dependencies[] = simplesamlphp_auth:simplesamlphp_auth

--- a/ideabank_users.module
+++ b/ideabank_users.module
@@ -7,21 +7,18 @@ function ideabank_users_form_alter(&$form, &$form_state, $form_id) {
 
             drupal_set_title('Log In');
 
-
-            if (_login_url_html()) {
-                $form['shibboleth'] = array(
-                            array('#markup' =>
-                                '' .
-                                '<h2>For MIT Community</h2>
-                                <div class="option-descr mit">
-                                <p>MIT students, staff, and faculty members can choose the option below to login with the MIT Kerberos account.
-                                ' .
-                                _login_url_html() .
-                                '</div>'
-                            ),
-                            '#weight' => -999,
-                        );
-            }
+            $form['links'] = array(
+                    array('#markup' =>
+                        '<h2>For MIT Community</h2>
+                        <div class="option-descr mit">
+                        <p>MIT students, staff, and faculty members can choose the option below to login with the MIT Kerberos account.</p>' .
+                        '<p>' .
+                         l(variable_get('simplesamlphp_auth_login_link_display_name', t('Federated Log In')),variable_get('simplesamlphp_auth_login_path', 'saml_login')) .
+                         '</p>' .
+                         '</div>'
+                    ),
+                    '#weight' => -999,
+                );
 
             if (!empty($_GET['destination']))
                 $cas_link = l('Sign in through MIT Alumni Infinite Connection',


### PR DESCRIPTION
As part of the move from our infrastructure to Pantheon, we need to change how we integrate Touchstone. We can't use Shibboleth anymore, and instead must use SimpleSAML. This PR alters our custom login screen markup to accommodate that change.

It also explicitly declares SimpleSAML_auth as a dependency for the project, Drupal > 7.40, and bumps the version string.

You can see the module in use on the dev OATF site.