### PR TITLE
Adds destination to post-login link

### DIFF
--- a/ideabank_users.info
+++ b/ideabank_users.info
@@ -2,6 +2,6 @@ name = Ideabank users
 description = Customize the login page for ideabank applications.
 core = 7.x
 package = MIT
-version = "7.x-1.2"
+version = "7.x-1.3"
 dependencies[] = drupal:system (>= 7.40)
 dependencies[] = simplesamlphp_auth:simplesamlphp_auth

--- a/ideabank_users.module
+++ b/ideabank_users.module
@@ -13,7 +13,10 @@ function ideabank_users_form_alter(&$form, &$form_state, $form_id) {
                         <div class="option-descr mit">
                         <p>MIT students, staff, and faculty members can choose the option below to login with the MIT Kerberos account.</p>' .
                         '<p>' .
-                         l(variable_get('simplesamlphp_auth_login_link_display_name', t('Federated Log In')),variable_get('simplesamlphp_auth_login_path', 'saml_login')) .
+                         l(variable_get('simplesamlphp_auth_login_link_display_name', t('Federated Log In')),
+                            variable_get('simplesamlphp_auth_login_path', 'saml_login'),
+                            array('query' => drupal_get_destination())
+                        ) .
                          '</p>' .
                          '</div>'
                     ),


### PR DESCRIPTION
This adds the `destination` querystring parameter to the login link that's sent to Touchstone. It allows our users to be directed back to forms like the Add Proposal, rather than landing back on our home page and needing to click around again.

This can be seen in place on the OATF dev site.